### PR TITLE
Fixes: Guild Group Name

### DIFF
--- a/main/src/features/guild-group/service.ts
+++ b/main/src/features/guild-group/service.ts
@@ -37,7 +37,7 @@ export class GuildGroupService implements IService {
       this.#guildsService.getGuildMembers(club_id)
     ]);
 
-    const groupName = `LGC: ${guild.club_name}`;
+    const groupName = "LGC - Гильдия";
     const group = await this.#lcuService.createFriendGroup(groupName);
     if (isNotExists(group)) {
       throw new Error(i18n.t("social.league-group.failure"));


### PR DESCRIPTION
**Problem**:
Users can't create a guild group in League because the Guild name is too long.

**Solution**:
Create a guild group with a static name